### PR TITLE
Feature. Add onOpen and onClose props on Dropdown & DropHolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tksui-components",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "private": false,
     "type": "module",
     "module": "lib/esm/index.js",

--- a/src/components/data-container/drop-holder/TDropHolder.interface.ts
+++ b/src/components/data-container/drop-holder/TDropHolder.interface.ts
@@ -20,6 +20,9 @@ export interface TDropHolderProps extends TBaseProps {
     textKey?: string,
     customItem?: ReactNode,
     offset?: string,
+
+    onOpen?(): void,
+    onClose?(): void,
 }
 
 

--- a/src/components/data-container/drop-holder/TDropHolder.tsx
+++ b/src/components/data-container/drop-holder/TDropHolder.tsx
@@ -10,7 +10,7 @@ import {
     useRef,
     useState,
 } from 'react';
-import {DropHolderAlignment, TDropHolderItem, TDropHolderProps, TDropHolderRef} from './TDropHolder.interface';
+import {DropHolderAlignment, TDropHolderItem, TDropHolderProps, TDropHolderRef} from '@/components';
 import useClickOutside from '@/common/hook/UseClickOutside';
 
 
@@ -110,10 +110,12 @@ const TDropHolder = forwardRef((props: TDropHolderProps, ref: ForwardedRef<TDrop
 
     const open = (): void => {
         setIsOpened(true);
+        props.onOpen?.();
     };
 
     const close = (): void => {
         setIsOpened(false);
+        props.onClose?.();
     };
 
     // endregion

--- a/src/components/input/dropdown/TDropdown.interface.ts
+++ b/src/components/input/dropdown/TDropdown.interface.ts
@@ -20,6 +20,7 @@ export interface TDropdownProps extends TValidatorProps, TBaseProps {
     multiple?: boolean,
     disabled?: boolean,
     noDetail?: boolean,
+    chip?: boolean,
     placeholder?: string,
     filterPlaceholder?: string,
 
@@ -29,8 +30,8 @@ export interface TDropdownProps extends TValidatorProps, TBaseProps {
     itemTemplate?: (item: TDropdownItem) => string,
 
     onChange(value: string | string[]): void,
-
-    chip?: boolean,
+    onOpen?(): void,
+    onClose?(): void,
 }
 
 

--- a/src/components/input/dropdown/TDropdown.tsx
+++ b/src/components/input/dropdown/TDropdown.tsx
@@ -12,7 +12,7 @@ import {
     useState,
 } from 'react';
 import useValidator from '@/common/hook/UseValidator';
-import {TDropdownItem, TDropdownProps, TDropdownRef} from './TDropdown.interface';
+import {TDropdownItem, TDropdownProps, TDropdownRef} from '@/components';
 import useClickOutside from '@/common/hook/UseClickOutside';
 import TCheckbox from '../checkbox/TCheckbox';
 import TTextField from '../text-field/TTextField';
@@ -82,16 +82,18 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
 
     const close = useCallback((setFocus: boolean): void => {
         setIsOpened(false);
+        props.onClose?.();
         setFilterText('');
         if (setFocus) {
             focusToControl();
         }
-    }, [focusToControl]);
+    }, [focusToControl, props]);
 
     const open = useCallback((): void => {
         setIsOpened(true);
+        props.onOpen?.();
         validator.clearValidation();
-    }, [validator]);
+    }, [props, validator]);
 
     const toggleIsOpened = useCallback((): void => {
         if (isOpened) {
@@ -154,7 +156,7 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
     const selectedClass = useMemo((): string => {
         const clazz: string[] = [];
 
-        if (props.value?.length === 0) clazz.push('t-dropdown__control__selected--empty');
+        if (props.value?.length === 0) { clazz.push('t-dropdown__control__selected--empty'); }
 
         return clazz.join(' ');
     }, [props.value?.length]);
@@ -162,9 +164,9 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
     const itemsClass = useMemo((): string => {
         const clazz: string[] = [];
 
-        if (isOpened) clazz.push('t-dropdown__items--open');
-        if (props.noDetail) clazz.push('t-dropdown__items--no-detail');
-        if (getFilteredItems().length === 0) clazz.push('t-dropdown__items--empty');
+        if (isOpened) { clazz.push('t-dropdown__items--open'); }
+        if (props.noDetail) { clazz.push('t-dropdown__items--no-detail'); }
+        if (getFilteredItems().length === 0) { clazz.push('t-dropdown__items--empty'); }
 
         return clazz.join(' ');
     }, [getFilteredItems, isOpened, props.noDetail]);
@@ -184,8 +186,8 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
     const rootStyle = useMemo((): CSSProperties => {
         let style: CSSProperties = {};
 
-        if (props.style) style = {...props.style};
-        if (props.width) style = {...style, width: props.width};
+        if (props.style) { style = {...props.style}; }
+        if (props.width) { style = {...style, width: props.width}; }
 
         return style;
     }, [props.style, props.width]);
@@ -298,7 +300,8 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
                  tabIndex={props.disabled ? -1 : 0}
                  onKeyDown={onKeyDownControl}
                  ref={controlRef}
-                 onClick={onClickControl}>
+                 onClick={onClickControl}
+                 data-testid={'dropdown-control'}>
 
                 {/* Control - Selected Items */}
                 <div className={`t-dropdown__control__selected ${selectedClass}`}>
@@ -344,7 +347,7 @@ const TDropdown = forwardRef((props: TDropdownProps, ref: Ref<TDropdownRef>) => 
                     )
                 }
                 <TIcon className={`t-dropdown__control__opener ${isOpened ? 't-dropdown__control__opener--open' : ''}`}
-                       
+
                        color={props.disabled ? themeToken.tGrayColor4 : themeToken.tGrayColor6}>arrow_drop_down</TIcon>
             </div>
 

--- a/tests/unit/react/tks/component/data-container/drop-holder/TDropHolder.test.tsx
+++ b/tests/unit/react/tks/component/data-container/drop-holder/TDropHolder.test.tsx
@@ -4,6 +4,8 @@ import TDropHolder from '~/data-container/drop-holder/TDropHolder';
 
 describe('TDropHolder', () => {
     const mockOnClickItem = jest.fn();
+    const mockOnOpen = jest.fn();
+    const mockOnClose = jest.fn();
     const baseProps = {
         children: <div>Holder Content</div>,
         items: [
@@ -115,6 +117,41 @@ describe('TDropHolder', () => {
 
             // Assert
             expect(root).not.toHaveClass('t-drop-holder--open');
+        });
+
+        it('When the onOpen prop is provided and user clicks root, it will be called exactly once.', async () => {
+
+            // Arrange
+            const user = userEvent.setup();
+            render(<TDropHolder {...baseProps} onOpen={mockOnOpen}>Test DropHolder</TDropHolder>);
+            const root = screen.getByTestId('drop-holder-root');
+
+            // Act
+            await act(async () => {
+                await user.click(root);
+            });
+
+            // Assert
+            expect(mockOnOpen).toHaveBeenCalledTimes(1);
+        });
+
+        it('When the onClose prop is provided and the user clicks the root element twice, it will be called exactly once.', async () => {
+
+            // Arrange
+            const user = userEvent.setup();
+            render(<TDropHolder {...baseProps} onClose={mockOnClose}>Test DropHolder</TDropHolder>);
+            const root = screen.getByTestId('drop-holder-root');
+
+            // Act
+            await act(async () => {
+                await user.click(root);
+            });
+            await act(async () => {
+                await user.click(root);
+            });
+
+            // Assert
+            expect(mockOnClose).toHaveBeenCalledTimes(1);
         });
 
         it('When user clicks outside, TDropHolder closes', async () => {

--- a/tests/unit/react/tks/component/data-container/search-box/TSearchBox.test.tsx
+++ b/tests/unit/react/tks/component/data-container/search-box/TSearchBox.test.tsx
@@ -101,7 +101,7 @@ describe('TSearchBox', () => {
                 .toHaveClass('t-button');
 
             expect(onSearch)
-                .toBeCalledTimes(1);
+                .toHaveBeenCalledTimes(1);
         });
 
         it('When the onSearch prop is supplied, the "조회" button should be displayed and working', async () => {
@@ -123,7 +123,7 @@ describe('TSearchBox', () => {
                 .toHaveClass('t-button');
 
             expect(onReset)
-                .toBeCalledTimes(1);
+                .toHaveBeenCalledTimes(1);
         });
 
     });

--- a/tests/unit/react/tks/component/data-container/step-box/TSearchBox.test.tsx
+++ b/tests/unit/react/tks/component/data-container/step-box/TSearchBox.test.tsx
@@ -101,7 +101,7 @@ describe('TSearchBox', () => {
                 .toHaveClass('t-button');
 
             expect(onSearch)
-                .toBeCalledTimes(1);
+                .toHaveBeenCalledTimes(1);
         });
 
         it('When the onSearch prop is supplied, the "조회" button should be displayed and working', async () => {
@@ -123,7 +123,7 @@ describe('TSearchBox', () => {
                 .toHaveClass('t-button');
 
             expect(onReset)
-                .toBeCalledTimes(1);
+                .toHaveBeenCalledTimes(1);
         });
 
     });

--- a/tests/unit/react/tks/component/icon/TIcon.test.tsx
+++ b/tests/unit/react/tks/component/icon/TIcon.test.tsx
@@ -159,7 +159,7 @@ describe('TIcon', () => {
             await user.click(root);
 
             // Assert
-            expect(mockOnClick).toBeCalledTimes(1);
+            expect(mockOnClick).toHaveBeenCalledTimes(1);
         });
 
 
@@ -176,7 +176,7 @@ describe('TIcon', () => {
             await user.click(root);
 
             // Assert
-            expect(mockOnClick).toBeCalledTimes(0);
+            expect(mockOnClick).toHaveBeenCalledTimes(0);
         });
 
         it('When the icon is clicked, the onClick event handler should receive the event parameter', async () => {
@@ -221,9 +221,9 @@ describe('TIcon', () => {
             await user.keyboard(' ');
 
             // Assert
-            expect(mockOnKeyDown).toBeCalledTimes(2);
-            expect(mockOnKeyDownEnter).toBeCalledTimes(1);
-            expect(mockOnKeyDownSpace).toBeCalledTimes(1);
+            expect(mockOnKeyDown).toHaveBeenCalledTimes(2);
+            expect(mockOnKeyDownEnter).toHaveBeenCalledTimes(1);
+            expect(mockOnKeyDownSpace).toHaveBeenCalledTimes(1);
         });
 
         it('When icon is disabled and user type something on Icon, onKeyDown event handler will be NOT executed', async () => {
@@ -248,9 +248,9 @@ describe('TIcon', () => {
             await user.keyboard(' ');
 
             // Assert
-            expect(mockOnKeyDown).toBeCalledTimes(0);
-            expect(mockOnKeyDownEnter).toBeCalledTimes(0);
-            expect(mockOnKeyDownSpace).toBeCalledTimes(0);
+            expect(mockOnKeyDown).toHaveBeenCalledTimes(0);
+            expect(mockOnKeyDownEnter).toHaveBeenCalledTimes(0);
+            expect(mockOnKeyDownSpace).toHaveBeenCalledTimes(0);
         });
 
     });

--- a/tests/unit/react/tks/component/input/dropdown/TDropdown.test.tsx
+++ b/tests/unit/react/tks/component/input/dropdown/TDropdown.test.tsx
@@ -1,18 +1,19 @@
 import {act, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import TTextField from '~/input/text-field/TTextField';
 import TDropdown from '~/input/dropdown/TDropdown';
 
 
 describe('TDropdown', () => {
 
     const mockOnChange = jest.fn();
+    const mockOnOpen = jest.fn();
+    const mockOnClose = jest.fn();
     const baseProps = {value: 'hello', onChange: mockOnChange, items: []};
 
     beforeEach(() => { mockOnChange.mockClear(); });
 
 
-    describe('style', () => {
+    describe('Style', () => {
         it('renders without errors', () => {
             render(<TDropdown {...baseProps}/>);
             expect(screen.getByTestId('dropdown-root')).toBeInTheDocument();
@@ -76,6 +77,45 @@ describe('TDropdown', () => {
             expect(root)
                 .toHaveClass('t-dropdown--underline');
         });
-    })
+    });
 
+
+    describe('Event', () => {
+
+        it('When the onOpen prop is provided and user clicks root, it will be called exactly once.', async () => {
+
+            // Arrange
+            const user = userEvent.setup();
+            render(<TDropdown {...baseProps} onOpen={mockOnOpen} />);
+            const control = screen.getByTestId('dropdown-control');
+
+            // Act
+            await act(async () => {
+                await user.click(control);
+            });
+
+            // Assert
+            expect(mockOnOpen).toHaveBeenCalledTimes(1);
+        });
+
+        it('When the onClose prop is provided and the user clicks the root element twice, it will be called exactly once.', async () => {
+
+            // Arrange
+            const user = userEvent.setup();
+            render(<TDropdown {...baseProps} onClose={mockOnClose} />);
+            const control = screen.getByTestId('dropdown-control');
+
+
+            // Act
+            await act(async () => {
+                await user.click(control);
+            });
+            await act(async () => {
+                await user.click(control);
+            });
+
+            // Assert
+            expect(mockOnClose).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/unit/react/tks/component/input/text-field/TTextField.test.tsx
+++ b/tests/unit/react/tks/component/input/text-field/TTextField.test.tsx
@@ -210,7 +210,7 @@ describe('TTextField', () => {
 
         // Assert
         expect(mockOnChange).toHaveBeenCalledWith('a');
-        expect(mockOnBlur).toBeCalledTimes(1);
+        expect(mockOnBlur).toHaveBeenCalledTimes(1);
     });
 
     it('When noTrim prop is applied, the input value is trimmed', async () => {
@@ -228,8 +228,8 @@ describe('TTextField', () => {
         });
 
         // Assert
-        expect(mockOnChange).toBeCalledTimes(0);
-        expect(mockOnBlur).toBeCalledTimes(1);
+        expect(mockOnChange).toHaveBeenCalledTimes(0);
+        expect(mockOnBlur).toHaveBeenCalledTimes(1);
     });
 
 
@@ -405,7 +405,7 @@ describe('TTextField', () => {
         });
 
         // Assert
-        expect(mockOnKeyDownEnter).toBeCalledTimes(1);
+        expect(mockOnKeyDownEnter).toHaveBeenCalledTimes(1);
     });
 
     it('When type any key, onKeyDown handler is called', async () => {
@@ -422,7 +422,7 @@ describe('TTextField', () => {
         });
 
         // Assert
-        expect(mockOnKeyDown).toBeCalledTimes(1);
+        expect(mockOnKeyDown).toHaveBeenCalledTimes(1);
     });
 
 


### PR DESCRIPTION
# Key Changes of PR
- Problem
  - Unable to detect open and close actions on Dropdown & DropHolder.

- Solution
  - Add onOpen and onClose props on Dropdown & DropHolder
