### PR TITLE
feature. Add noRowDivider prop to TFormSection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tksui-components",
-    "version": "0.6.6",
+    "version": "0.6.7",
     "private": false,
     "type": "module",
     "module": "lib/esm/index.js",

--- a/src/components/data-container/form-section/TFormSection.interface.ts
+++ b/src/components/data-container/form-section/TFormSection.interface.ts
@@ -12,6 +12,7 @@ export interface TFormSectionProps extends TBaseProps {
     customInformation?: ReactElement,
 
     labelWidth?: string,
+    noRowDivider?: boolean,
 
     leftAction?: ReactElement,
     rightAction?: ReactElement,

--- a/src/components/data-container/form-section/TFormSection.tsx
+++ b/src/components/data-container/form-section/TFormSection.tsx
@@ -14,10 +14,12 @@ const TFormSection = (props: TFormSectionProps) => {
 
         if (props.className) { clazz.push(props.className); }
 
+        if (props.noRowDivider) { clazz.push('t-form-section--no-row-divider'); }
+
         clazz.push(`t-form-section--form-label-item-align--${props.formLabelItemAlign}`);
 
         return clazz.join(' ');
-    }, [props.className, props.formLabelItemAlign]);
+    }, [props.className, props.formLabelItemAlign, props.noRowDivider]);
 
     const rootStyle = useMemo((): CSSProperties => {
 

--- a/src/styles/component/data-container/form-section/TFormSection.scss
+++ b/src/styles/component/data-container/form-section/TFormSection.scss
@@ -47,6 +47,7 @@
             }
         }
     }
+
 }
 
 .t-section.t-form-section {
@@ -72,6 +73,26 @@
         padding-bottom: $t-spacing-24;
     }
 }
+
+.t-form-section--no-row-divider {
+    .t-form-section-row {
+
+        &:first-child {
+            padding-bottom: $t-spacing-8;
+            border-bottom: none;
+        }
+        &:not(:last-child, :first-child) {
+            border: none;
+            padding: $t-spacing-8 $t-spacing-24;
+        }
+        &:last-child {
+            padding-top: $t-spacing-8;
+            border-top: none;
+        }
+    }
+}
+
+
 
 .t-form-section-item {
     position: relative;

--- a/stories/components/data-container/form-section/TFormSection.stories.tsx
+++ b/stories/components/data-container/form-section/TFormSection.stories.tsx
@@ -9,7 +9,6 @@ import TTextField from '@/components/input/text-field/TTextField';
 import useInputState from '@/common/hook/UseInputState';
 import TDropdown from '@/components/input/dropdown/TDropdown';
 import TToast, {notify} from '@/components/guide/toast/TToast';
-import TTextArea from '~/input/text-area/TTextArea';
 
 
 const meta: Meta<typeof TFormSection> = {
@@ -51,7 +50,7 @@ const Template = (args: TFormSectionProps) => {
             <TToast/>
             <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
                 <TFormSection label={'Basic Properties'} column={2} {...args} customInformation={<>앱 생성 양식 예제입니다.</>}
-                              leftAction={leftAction()} rightAction={rightAction()}>
+                              leftAction={leftAction()} rightAction={rightAction()} >
                     <TFormSectionRow>
                         <TFormSectionItem label={'Name'} required>
                             <TTextField counter={30} {...name} />
@@ -108,10 +107,37 @@ const Template = (args: TFormSectionProps) => {
 
                     <TFormSectionRow>
                         <TFormSectionItem label={'Description'} span={2}>
-                            <TTextArea counter={100} {...profile} />
+                            <TTextField multiline counter={100} rows={5} {...profile} />
                         </TFormSectionItem>
                     </TFormSectionRow>
                 </TFormSection>
+
+                <TFormSection label={'Properties'} column={2} noRowDivider>
+                    <TFormSectionRow>
+                        <TFormSectionItem label={'Artifact URL'} required>
+                            <TTextField {...artifactUrl} />
+                        </TFormSectionItem>
+                        <TFormSectionItem label={'Port'}>
+                            <TTextField counter={20} {...port} placeholder={'123.123.123.123'}/>
+                        </TFormSectionItem>
+                    </TFormSectionRow>
+
+                    <TFormSectionRow>
+                        <TFormSectionItem label={'Profile'}>
+                            <TTextField counter={20} {...profile} />
+                        </TFormSectionItem>
+                        <TFormSectionItem label={'Resource Spec'}>
+                            <TDropdown items={resourceSpecItems} {...resourceSpec} />
+                        </TFormSectionItem>
+                    </TFormSectionRow>
+
+                    <TFormSectionRow>
+                        <TFormSectionItem label={'Description'} span={2}>
+                            <TTextField multiline counter={100} rows={5} {...profile} />
+                        </TFormSectionItem>
+                    </TFormSectionRow>
+                </TFormSection>
+
                 <TFormSection label={'Basic Properties'} formLabelItemAlign={'vertical'} column={2}
                               leftAction={leftAction()} rightAction={rightAction()}>
                     <TFormSectionRow>

--- a/tests/unit/react/tks/component/data-container/form-section/TFormSection.test.tsx
+++ b/tests/unit/react/tks/component/data-container/form-section/TFormSection.test.tsx
@@ -96,6 +96,30 @@ describe('TFormSection', () => {
                 .toHaveClass('t-form-section__content__info__content');
         });
 
+        it('When noRowDivider prop is applied, it should be displayed on row area', () => {
+
+            // Arrange
+            const firstRowContent = 'First Row Content';
+            const middleRowContent = 'Middle Row Content';
+            const lastRowContent = 'Last Row Content';
+            render(
+                <TFormSection noRowDivider>
+                    <TFormSectionRow>{firstRowContent}</TFormSectionRow>
+                    <TFormSectionRow>{middleRowContent}</TFormSectionRow>
+                    <TFormSectionRow>{lastRowContent}</TFormSectionRow>
+                </TFormSection>,
+            );
+
+            const firstRowRoot = screen.getByText(firstRowContent);
+            const middleRowRoot = screen.getByText(middleRowContent);
+            const lastRowRoot = screen.getByText(lastRowContent);
+
+            // Assert
+            expect(firstRowRoot).toHaveStyle({borderBottom: 'none'});
+            expect(middleRowRoot).toHaveStyle({border: 'none'});
+            expect(lastRowRoot).toHaveStyle({borderTop: 'none'});
+        });
+
         it('When customInformation prop is applied, it should be displayed on information area', () => {
 
             // Arrange


### PR DESCRIPTION
# Key Changes of PR
- Add noRowDivider prop

```typescript
export interface TFormSectionProps extends TBaseProps {
    ...
    noRowDivider?: boolean,
    ...
}

```


# Screenshots
## noRowDivider = false or undefined
<img width="1012" alt="image" src="https://github.com/openinfradev/tksui-components/assets/154313869/adc6cb41-a6d6-4aa4-9f36-bd1f2c6de6b7">

## noRowDivider = true
<img width="1013" alt="image" src="https://github.com/openinfradev/tksui-components/assets/154313869/407226ec-e70a-4701-a3c3-18729d6b6222">

